### PR TITLE
fix: Incorrect attribute parsing in CA expressions without spaces between individual terms

### DIFF
--- a/clients/vscode-hlasmplugin/CHANGELOG.md
+++ b/clients/vscode-hlasmplugin/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixed
 - Incorrect attribute values generated when literals are substituted in CA expressions
 - AINSERT grammar tests improved
+- Incorrect attribute parsing in CA expressions without spaces between individual terms
 
 ## [1.2.0](https://github.com/eclipse/che-che4z-lsp-for-hlasm/compare/1.1.0...1.2.0) (2022-05-11)
 

--- a/parser_library/src/analyzer.cpp
+++ b/parser_library/src/analyzer.cpp
@@ -14,6 +14,7 @@
 
 #include "analyzer.h"
 
+#include "hlasmparser.h"
 #include "parsing/error_strategy.h"
 #include "processing/preprocessor.h"
 
@@ -100,6 +101,8 @@ analyzing_context analyzer::context() const { return ctx_; }
 context::hlasm_context& analyzer::hlasm_ctx() { return *ctx_.hlasm_ctx; }
 
 parsing::hlasmparser& analyzer::parser() { return mngr_.opencode_parser(); }
+
+size_t analyzer::debug_syntax_errors() { return mngr_.opencode_parser().getNumberOfSyntaxErrors(); }
 
 const semantics::source_info_processor& analyzer::source_processor() const { return src_proc_; }
 

--- a/parser_library/src/analyzer.h
+++ b/parser_library/src/analyzer.h
@@ -21,7 +21,6 @@
 #include "analyzing_context.h"
 #include "context/hlasm_context.h"
 #include "diagnosable_ctx.h"
-#include "hlasmparser.h"
 #include "lexing/token_stream.h"
 #include "lsp/lsp_context.h"
 #include "parsing/parser_error_listener.h"
@@ -29,6 +28,10 @@
 #include "processing/processing_manager.h"
 #include "virtual_file_monitor.h"
 #include "workspaces/parse_lib_provider.h"
+
+namespace hlasm_plugin::parser_library::parsing {
+class hlasmparser;
+} // namespace hlasm_plugin::parser_library::parsing
 
 namespace hlasm_plugin::parser_library {
 
@@ -139,6 +142,7 @@ public:
     void register_stmt_analyzer(processing::statement_analyzer* stmt_analyzer);
 
     parsing::hlasmparser& parser(); // for testing only
+    size_t debug_syntax_errors(); // for testing only
 };
 
 } // namespace hlasm_plugin::parser_library

--- a/parser_library/src/lexing/lexer.cpp
+++ b/parser_library/src/lexing/lexer.cpp
@@ -460,10 +460,8 @@ bool lexer::is_ord_char() const { return ord_char(input_state_->c); }
 
 bool lexer::is_space() const { return input_state_->c == ' ' || input_state_->c == '\n' || input_state_->c == '\r'; }
 
-bool is_consuming_data_attribute(char_t c)
+bool is_data_attribute(char_t c)
 {
-    // Although there are more data attributes (N, K, D), only these 5 consume the apostrophe right away, so that it
-    // cannot denote the beginning of string
     auto tmp = std::toupper(c);
     return tmp == 'O' || tmp == 'S' || tmp == 'I' || tmp == 'L' || tmp == 'T' || tmp == 'N' || tmp == 'K' || tmp == 'D';
 }
@@ -486,7 +484,7 @@ void lexer::lex_word()
         ord &= curr_ord;
 
         num &= (input_state_->c >= '0' && input_state_->c <= '9');
-        last_char_data_attr = is_consuming_data_attribute(input_state_->c) && w_len == 0;
+        last_char_data_attr = is_data_attribute(input_state_->c) && w_len == 0;
 
         if (creating_var_symbol_ && !ord && w_len > 0 && w_len <= 63)
         {

--- a/parser_library/src/lexing/lexer.cpp
+++ b/parser_library/src/lexing/lexer.cpp
@@ -460,12 +460,12 @@ bool lexer::is_ord_char() const { return ord_char(input_state_->c); }
 
 bool lexer::is_space() const { return input_state_->c == ' ' || input_state_->c == '\n' || input_state_->c == '\r'; }
 
-bool lexer::is_consuming_data_attribute() const
+bool is_consuming_data_attribute(char_t c)
 {
     // Although there are more data attributes (N, K, D), only these 5 consume the apostrophe right away, so that it
     // cannot denote the beginning of string
-    auto tmp = std::toupper(input_state_->c);
-    return tmp == 'O' || tmp == 'S' || tmp == 'I' || tmp == 'L' || tmp == 'T';
+    auto tmp = std::toupper(c);
+    return tmp == 'O' || tmp == 'S' || tmp == 'I' || tmp == 'L' || tmp == 'T' || tmp == 'N' || tmp == 'K' || tmp == 'D';
 }
 
 void lexer::lex_word()
@@ -475,14 +475,18 @@ void lexer::lex_word()
     bool num = (input_state_->c >= '0' && input_state_->c <= '9');
     size_t last_part_ord_len = 0;
     size_t w_len = 0;
+    bool last_ord = true;
     while (!is_space() && !eof() && !identifier_divider() && before_end())
     {
         bool curr_ord = is_ord_char();
+        if (!last_ord && curr_ord)
+            break;
+
         last_part_ord_len = curr_ord ? last_part_ord_len + 1 : 0;
         ord &= curr_ord;
 
         num &= (input_state_->c >= '0' && input_state_->c <= '9');
-        last_char_data_attr = is_consuming_data_attribute();
+        last_char_data_attr = is_consuming_data_attribute(input_state_->c) && w_len == 0;
 
         if (creating_var_symbol_ && !ord && w_len > 0 && w_len <= 63)
         {
@@ -492,6 +496,7 @@ void lexer::lex_word()
 
         consume();
         ++w_len;
+        last_ord = curr_ord;
     }
 
     bool var_sym_tmp = creating_var_symbol_;

--- a/parser_library/src/lexing/lexer.h
+++ b/parser_library/src/lexing/lexer.h
@@ -94,7 +94,6 @@ public:
     // is next input char an ord char?
     bool is_ord_char() const;
     bool is_space() const;
-    bool is_consuming_data_attribute() const;
     void set_unlimited_line(bool unlimited_lines);
     // set lexer's input state to file position
     void set_file_offset(position file_offset, bool process_allowed = false);

--- a/parser_library/src/parsing/grammar/ca_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/ca_expr_rules.g4
@@ -234,7 +234,7 @@ var_symbol returns [vs_ptr vs]
 	);
 
 data_attribute returns [context::data_attr_kind attribute, std::variant<context::id_index, semantics::vs_ptr, semantics::literal_si> value, range value_range]
-	: ORDSYMBOL (attr|apostrophe_as_attr) data_attribute_value
+	: ORDSYMBOL attr data_attribute_value
 	{
 		collector.add_hl_symbol(token_info(provider.get_range($ORDSYMBOL), hl_scopes::data_attr_type));
 		$attribute = get_attribute($ORDSYMBOL->getText());

--- a/parser_library/src/parsing/grammar/ca_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/ca_expr_rules.g4
@@ -81,7 +81,7 @@ term returns [ca_expr_ptr ca_expr]
 		collector.add_hl_symbol(token_info(r, hl_scopes::string));
 		$ca_expr = std::move($ca_string.ca_expr);
 	}
-	| {is_data_attr()}? data_attribute
+	| data_attribute
 	{
 		auto r = provider.get_range($data_attribute.ctx);
 		auto val_range = $data_attribute.value_range;

--- a/parser_library/src/parsing/grammar/ca_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/ca_expr_rules.g4
@@ -81,7 +81,7 @@ term returns [ca_expr_ptr ca_expr]
 		collector.add_hl_symbol(token_info(r, hl_scopes::string));
 		$ca_expr = std::move($ca_string.ca_expr);
 	}
-	| data_attribute
+	| {is_data_attr()}? data_attribute
 	{
 		auto r = provider.get_range($data_attribute.ctx);
 		auto val_range = $data_attribute.value_range;

--- a/parser_library/src/parsing/grammar/deferred_operand_rules.g4
+++ b/parser_library/src/parsing/grammar/deferred_operand_rules.g4
@@ -30,9 +30,36 @@ deferred_entry returns [std::vector<vs_ptr> vs]
 	| dot
 	| lpar
 	| rpar
-	| attr
+	| ap1=ATTR
+	{disable_ca_string();}
+	(
+		(
+			(APOSTROPHE|ATTR) (APOSTROPHE|ATTR)
+			|
+			(
+				{std::string name;}
+				AMPERSAND
+				ORDSYMBOL {name += $ORDSYMBOL->getText();}
+				(ORDSYMBOL {name += $ORDSYMBOL->getText();}|NUM {name += $NUM->getText();})*
+				{
+					auto r = provider.get_range($AMPERSAND,_input->LT(-1));
+					$vs.push_back(std::make_unique<basic_variable_symbol>(hlasm_ctx->ids().add(std::move(name)), std::vector<ca_expr_ptr>(), r));
+					collector.add_hl_symbol(token_info(r,hl_scopes::var_symbol));
+				}
+			)
+			|
+			l_sp_ch_v
+		)*
+		ap2=(APOSTROPHE|ATTR)
+		{
+			collector.add_hl_symbol(token_info(provider.get_range($ap1,$ap2),hl_scopes::string));
+		}
+		|
+		{collector.add_hl_symbol(token_info(provider.get_range($ap1),hl_scopes::operator_symbol)); }
+	)
+	{enable_ca_string();}
 	|
-	ap1=(APOSTROPHE|ATTR)
+	ap1=APOSTROPHE
 	{disable_ca_string();}
 	(
 		(APOSTROPHE|ATTR) (APOSTROPHE|ATTR)

--- a/parser_library/src/parsing/grammar/deferred_operand_rules.g4
+++ b/parser_library/src/parsing/grammar/deferred_operand_rules.g4
@@ -32,7 +32,7 @@ deferred_entry returns [std::vector<vs_ptr> vs]
 	| rpar
 	| attr
 	|
-	ap1=APOSTROPHE
+	ap1=(APOSTROPHE|ATTR)
 	{disable_ca_string();}
 	(
 		(APOSTROPHE|ATTR) (APOSTROPHE|ATTR)

--- a/parser_library/src/parsing/grammar/hlasmparser.g4
+++ b/parser_library/src/parsing/grammar/hlasmparser.g4
@@ -247,8 +247,6 @@ apostrophe
 	: APOSTROPHE;
 attr
 	: ATTR {collector.add_hl_symbol(token_info(provider.get_range( $ATTR),hl_scopes::operator_symbol)); };
-apostrophe_as_attr
-	: APOSTROPHE {collector.add_hl_symbol(token_info(provider.get_range($APOSTROPHE),hl_scopes::operator_symbol)); };
 lpar
 	: LPAR { collector.add_hl_symbol(token_info(provider.get_range( $LPAR),hl_scopes::operator_symbol)); };
 rpar 

--- a/parser_library/src/parsing/grammar/machine_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/machine_expr_rules.g4
@@ -68,37 +68,40 @@ mach_term returns [mach_expr_ptr m_e]
 	{
 		$m_e = std::make_unique<mach_expr_location_counter>( provider.get_range( $mach_location_counter.ctx));
 	}
-	| mach_data_attribute
-	{
-		auto rng = provider.get_range($mach_data_attribute.ctx);
-		auto attr = $mach_data_attribute.attribute;
-		if(attr == data_attr_kind::UNKNOWN)
-			$m_e = std::make_unique<mach_expr_default>(rng);
-		else
-			$m_e = std::visit([rng, attr, symbol_rng = $mach_data_attribute.symbol_rng](auto& arg) -> mach_expr_ptr {
-				if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,std::monostate>) {
-					return std::make_unique<mach_expr_default>(rng);
-				}
-				else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,int>) {
-					return std::make_unique<mach_expr_constant>(arg, symbol_rng);
-				}
-				else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,std::unique_ptr<mach_expr_literal>>) {
-					return std::make_unique<mach_expr_data_attr_literal>(std::move(arg), attr, rng, symbol_rng);
-				}
-				else {
-					return std::make_unique<mach_expr_data_attr>(arg.first, arg.second, attr, rng, symbol_rng);
-				}
-			}, $mach_data_attribute.data);
-	}
-	| self_def_term
-	{
-		$m_e = std::make_unique<mach_expr_constant>($self_def_term.value, provider.get_range( $self_def_term.ctx));
-	}
-	| id
-	{
-		collector.add_hl_symbol(token_info(provider.get_range( $id.ctx),hl_scopes::ordinary_symbol));
-		$m_e = std::make_unique<mach_expr_symbol>($id.name, $id.using_qualifier, provider.get_range( $id.ctx));
-	}
+	|
+	(
+		mach_data_attribute
+		{
+			auto rng = provider.get_range($mach_data_attribute.ctx);
+			auto attr = $mach_data_attribute.attribute;
+			if(attr == data_attr_kind::UNKNOWN)
+				$m_e = std::make_unique<mach_expr_default>(rng);
+			else
+				$m_e = std::visit([rng, attr, symbol_rng = $mach_data_attribute.symbol_rng](auto& arg) -> mach_expr_ptr {
+					if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,std::monostate>) {
+						return std::make_unique<mach_expr_default>(rng);
+					}
+					else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,int>) {
+						return std::make_unique<mach_expr_constant>(arg, symbol_rng);
+					}
+					else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>,std::unique_ptr<mach_expr_literal>>) {
+						return std::make_unique<mach_expr_data_attr_literal>(std::move(arg), attr, rng, symbol_rng);
+					}
+					else {
+						return std::make_unique<mach_expr_data_attr>(arg.first, arg.second, attr, rng, symbol_rng);
+					}
+				}, $mach_data_attribute.data);
+		}
+		| self_def_term
+		{
+			$m_e = std::make_unique<mach_expr_constant>($self_def_term.value, provider.get_range( $self_def_term.ctx));
+		}
+		| id
+		{
+			collector.add_hl_symbol(token_info(provider.get_range( $id.ctx),hl_scopes::ordinary_symbol));
+			$m_e = std::make_unique<mach_expr_symbol>($id.name, $id.using_qualifier, provider.get_range( $id.ctx));
+		}
+	)
 	| signed_num
 	{
 		collector.add_hl_symbol(token_info(provider.get_range( $signed_num.ctx),hl_scopes::number));

--- a/parser_library/src/parsing/grammar/machine_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/machine_expr_rules.g4
@@ -68,7 +68,7 @@ mach_term returns [mach_expr_ptr m_e]
 	{
 		$m_e = std::make_unique<mach_expr_location_counter>( provider.get_range( $mach_location_counter.ctx));
 	}
-	| {is_data_attr()}? mach_data_attribute
+	| mach_data_attribute
 	{
 		auto rng = provider.get_range($mach_data_attribute.ctx);
 		auto attr = $mach_data_attribute.attribute;

--- a/parser_library/src/parsing/grammar/machine_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/machine_expr_rules.g4
@@ -142,7 +142,7 @@ literal_internal returns [std::optional<data_definition> value]
 	};
 
 mach_data_attribute returns [data_attr_kind attribute, std::variant<std::monostate, std::pair<id_index,id_index>, std::unique_ptr<mach_expr_literal>, int> data, range symbol_rng]
-	: ORDSYMBOL (attr|apostrophe_as_attr) {auto lit_restore = enable_literals();}
+	: ORDSYMBOL attr {auto lit_restore = enable_literals();}
 	{
 		collector.add_hl_symbol(token_info(provider.get_range($ORDSYMBOL), hl_scopes::data_attr_type));
 		$attribute = get_attribute($ORDSYMBOL->getText());

--- a/parser_library/src/parsing/grammar/macro_operand_rules.g4
+++ b/parser_library/src/parsing/grammar/macro_operand_rules.g4
@@ -194,7 +194,6 @@ mac_entry [bool top_level = true] returns [concat_chain chain]
 		ap1=ATTR
 		{
 			$chain.push_back(std::make_unique<char_str_conc>("'", provider.get_range($ap1)));
-			bool attribute = true;
 		}
 		(
 			{!is_previous_attribute_consuming($top_level, _input->LT(-2))}?
@@ -209,12 +208,12 @@ mac_entry [bool top_level = true] returns [concat_chain chain]
 			{
 				$chain.push_back(std::make_unique<char_str_conc>("'", provider.get_range($ap2)));
 				collector.add_hl_symbol(token_info(provider.get_range($ap1,$ap2),hl_scopes::string));
-				attribute = false;
 			}
-		)?
-		{
-			if (attribute)
+			|
+			{is_previous_attribute_consuming($top_level, _input->LT(-2))}?
+			{
 				collector.add_hl_symbol(token_info(provider.get_range($ap1),hl_scopes::operator_symbol));
-		}
+			}
+		)
 	)+
 	;

--- a/parser_library/src/parsing/parser_error_listener.cpp
+++ b/parser_library/src/parsing/parser_error_listener.cpp
@@ -141,7 +141,7 @@ void parser_error_listener_base::syntaxError(
             {
                 auto first = ctx->getStart();
                 if (!first)
-                    return -1;
+                    break;
 
                 if (first->getType() == antlr4::Token::EOF)
                 {
@@ -150,6 +150,7 @@ void parser_error_listener_base::syntaxError(
                 }
                 return (int)first->getTokenIndex();
             }
+            return -1;
         }(dynamic_cast<const antlr4::ParserRuleContext*>(excp.getCtx()));
 
         // find first eoln

--- a/parser_library/src/parsing/parser_error_listener.cpp
+++ b/parser_library/src/parsing/parser_error_listener.cpp
@@ -68,7 +68,8 @@ void iterate_error_stream(antlr4::TokenStream* input_stream,
     bool& sign_preceding,
     bool& unexpected_sign,
     bool& odd_apostrophes,
-    bool& ampersand_followed)
+    bool& ampersand_followed,
+    bool& attr_last)
 {
     int parenthesis = 0;
     int apostrophes = 0;
@@ -96,7 +97,12 @@ void iterate_error_stream(antlr4::TokenStream* input_stream,
             if (is_comparative_sign(type))
                 unexpected_sign = true;
             if (type == APOSTROPHE)
+            {
                 apostrophes++;
+                attr_last = false;
+            }
+            if (type == ATTR)
+                attr_last = true;
         }
         // if there is right bracket preceding left bracket
         if (parenthesis > 0)
@@ -130,6 +136,15 @@ void parser_error_listener_base::syntaxError(
         auto start_token = excp.getStartToken();
         int start_index = (int)start_token->getTokenIndex();
 
+        if (auto ctx = dynamic_cast<const antlr4::ParserRuleContext*>(excp.getCtx()); ctx)
+        {
+            if (auto first = ctx->getStart())
+            {
+                if (auto idx = (int)first->getStartIndex(); idx != -1 && idx < start_index)
+                    start_index = idx;
+            }
+        }
+
         // find first eoln
 
         auto first_symbol_type = input_stream->get(start_index)->getType();
@@ -159,6 +174,7 @@ void parser_error_listener_base::syntaxError(
         bool unexpected_sign = false;
         bool odd_apostrophes = false;
         bool ampersand_followed = true;
+        bool attr_last = false;
 
         iterate_error_stream(input_stream,
             start_index,
@@ -170,7 +186,8 @@ void parser_error_listener_base::syntaxError(
             sign_preceding,
             unexpected_sign,
             odd_apostrophes,
-            ampersand_followed);
+            ampersand_followed,
+            attr_last);
 
         // right paranthesis has no left match
         if (right_prec)
@@ -224,6 +241,9 @@ void parser_error_listener_base::syntaxError(
                 diagnostic_severity::error,
                 "S0004",
                 "Unfinished statement, the label cannot be alone on a line");
+        else if (attr_last && is_expected(APOSTROPHE, expected_tokens))
+            add_parser_diagnostic(
+                range(position(line, char_pos_in_line)), diagnostic_severity::error, "S0005", "Expected an apostrophe");
         // other undeclared errors
         else
             add_parser_diagnostic(

--- a/parser_library/src/parsing/parser_impl.cpp
+++ b/parser_library/src/parsing/parser_impl.cpp
@@ -225,7 +225,7 @@ bool parser_impl::is_previous_attribute_consuming(bool top_level, const antlr4::
         return false;
 
     auto text = token->getText();
-    if (text.empty() || text.size() >= 2 && std::isalpha((unsigned char)text[text.size() - 2]))
+    if (text.size() != 1)
         return false;
 
     auto tmp = std::toupper((unsigned char)text.back());

--- a/parser_library/src/parsing/parser_impl.cpp
+++ b/parser_library/src/parsing/parser_impl.cpp
@@ -82,13 +82,6 @@ bool parser_impl::is_self_def()
     return tmp == "B" || tmp == "X" || tmp == "C" || tmp == "G";
 }
 
-bool parser_impl::is_data_attr()
-{
-    std::string tmp(_input->LT(1)->getText());
-    context::to_upper(tmp);
-    return tmp == "D" || tmp == "O" || tmp == "N" || tmp == "S" || tmp == "K" || tmp == "I" || tmp == "L" || tmp == "T";
-}
-
 bool parser_impl::is_var_def()
 {
     auto [_, opcode] = *proc_status;

--- a/parser_library/src/parsing/parser_impl.h
+++ b/parser_library/src/parsing/parser_impl.h
@@ -104,7 +104,6 @@ protected:
     void enable_continuation();
     void disable_continuation();
     bool is_self_def();
-    bool is_data_attr();
     bool is_var_def();
 
     bool allow_ca_string() const { return ca_string_enabled; }

--- a/parser_library/test/CMakeLists.txt
+++ b/parser_library/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(library_test)
 
 target_sources(library_test PRIVATE
 	aread_time_test.cpp
+	common_testing.cpp
 	common_testing.h
 	diagnosable_ctx_test.cpp
 	diagnostics_check_test.cpp

--- a/parser_library/test/checking/asm_instr_diag_test.cpp
+++ b/parser_library/test/checking/asm_instr_diag_test.cpp
@@ -25,7 +25,7 @@ TEST(diagnostics, org_incorrect_second_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A115");
 }
@@ -39,7 +39,7 @@ TEST(diagnostics, exitctl_op_incorrect_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A020");
 }
@@ -53,7 +53,7 @@ TEST(diagnostics, exitctl_op_incorrect_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A131");
 }
@@ -67,7 +67,7 @@ TEST(diagnostics, extrn_incorrect_part_operand)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A129");
 }
@@ -81,7 +81,7 @@ TEST(diagnostics, extrn_incorrect_complex_operand)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A129");
 }
@@ -95,7 +95,7 @@ TEST(diagnostics, ictl_empty_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A021");
 }
@@ -109,7 +109,7 @@ TEST(diagnostics, ictl_undefined_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A242");
 }
@@ -123,7 +123,7 @@ TEST(diagnostics, ictl_incorrect_begin_val)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A123");
 }
@@ -137,7 +137,7 @@ TEST(diagnostics, ictl_incorrect_continuation_val)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A126");
 }
@@ -151,7 +151,7 @@ TEST(diagnostics, ictl_incorrect_end_begin_diff)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A125");
 }
@@ -165,7 +165,7 @@ TEST(diagnostics, ictl_incorrect_continuation_begin_diff)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A127");
 }
@@ -179,7 +179,7 @@ TEST(diagnostics, end_incorrect_first_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A243");
 }
@@ -194,7 +194,7 @@ simple equ 2
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A001");
 }
@@ -209,7 +209,7 @@ TEST(diagnostics, end_incorrect_language_third_char)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A140");
 }
@@ -223,7 +223,7 @@ TEST(diagnostics, end_incorrect_language_second_char)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A139");
 }
@@ -237,7 +237,7 @@ TEST(diagnostics, end_incorrect_language_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A137");
 }
@@ -251,7 +251,7 @@ TEST(diagnostics, drop_incorrect_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A141");
 }
@@ -265,7 +265,7 @@ TEST(diagnostics, cnop_incorrect_first_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A143");
 }
@@ -279,7 +279,7 @@ TEST(diagnostics, cnop_incorrect_second_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A143");
 }
@@ -293,7 +293,7 @@ TEST(diagnostics, cnop_incorrect_boundary)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A145");
 }
@@ -307,7 +307,7 @@ TEST(diagnostics, ccw_unspecified_operand)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A147");
 }
@@ -321,7 +321,7 @@ TEST(diagnostics, ccw_incorrect_first_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A143");
 }
@@ -335,7 +335,7 @@ TEST(diagnostics, ccw_incorrect_second_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A247");
 }
@@ -349,7 +349,7 @@ TEST(diagnostics, space_incorrect_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A240");
 }
@@ -363,7 +363,7 @@ TEST(diagnostics, space_incorrect_op_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A148");
 }
@@ -377,7 +377,7 @@ TEST(diagnostics, cattr_incorrect_simple_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A149");
 }
@@ -391,7 +391,7 @@ TEST(diagnostics, cattr_incorrect_complex_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A149");
 }
@@ -405,7 +405,7 @@ TEST(diagnostics, cattr_incorrect_complex_params)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A016");
 }
@@ -419,7 +419,7 @@ TEST(diagnostics, cattr_incorrect_rmode_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A204");
 }
@@ -433,7 +433,7 @@ TEST(diagnostics, cattr_incorrect_align_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A205");
 }
@@ -447,7 +447,7 @@ TEST(diagnostics, cattr_incorrect_fill_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A206");
 }
@@ -461,7 +461,7 @@ TEST(diagnostics, cattr_incorrect_priority_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A208");
 }
@@ -475,7 +475,7 @@ TEST(diagnostics, cattr_incorrect_part_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A207");
 }
@@ -489,7 +489,7 @@ TEST(diagnostics, cattr_empty_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A021");
 }
@@ -503,7 +503,7 @@ TEST(diagnostics, ainsert_incorrect_string)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "A301" }));
 }
 
@@ -516,7 +516,7 @@ TEST(diagnostics, ainsert_incorrect_second_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A156");
 }
@@ -530,7 +530,7 @@ TEST(diagnostics, adata_incorrect_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A158");
 }
@@ -544,7 +544,7 @@ TEST(diagnostics, adata_incorrect_last_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A239");
 }
@@ -558,7 +558,7 @@ TEST(diagnostics, adata_string_not_enclosed)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A300");
 }
@@ -577,7 +577,7 @@ TEST(diagnostics, adata_string_too_long)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A160");
 }
@@ -591,7 +591,7 @@ TEST(diagnostics, acontrol_incorrect_simple_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A161");
 }
@@ -605,7 +605,7 @@ TEST(diagnostics, acontrol_incorrect_complex_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A161");
 }
@@ -619,7 +619,7 @@ TEST(diagnostics, acontrol_compat_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A209");
 }
@@ -633,7 +633,7 @@ TEST(diagnostics, acontrol_flag_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A211");
 }
@@ -647,7 +647,7 @@ TEST(diagnostics, acontrol_optable_params_size)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A018");
 }
@@ -661,7 +661,7 @@ TEST(diagnostics, acontrol_optable_first_params_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A212");
 }
@@ -675,7 +675,7 @@ TEST(diagnostics, acontrol_optable_second_params_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A213");
 }
@@ -689,7 +689,7 @@ TEST(diagnostics, acontrol_typecheck_param)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A214");
 }
@@ -703,7 +703,7 @@ TEST(diagnostics, acontrol_empty_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A021");
 }
@@ -718,7 +718,7 @@ TEST(diagnostics, extrn_empty_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A021");
 }
@@ -732,7 +732,7 @@ TEST(diagnostics, xattr_scope_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A200");
 }
@@ -746,7 +746,7 @@ TEST(diagnostics, xattr_linkage_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A201");
 }
@@ -760,7 +760,7 @@ TEST(diagnostics, xattr_reference_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A288");
 }
@@ -774,7 +774,7 @@ TEST(diagnostics, xattr_reference_direct_indirect_options)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A202");
 }
@@ -788,7 +788,7 @@ TEST(diagnostics, xattr_reference_number_of_params)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A018");
 }
@@ -802,7 +802,7 @@ TEST(diagnostics, mnote_incorrect_message)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A119");
 }
@@ -816,7 +816,7 @@ TEST(diagnostics, mnote_first_op_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A119");
 }
@@ -830,7 +830,7 @@ TEST(diagnostics, mnote_first_op_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "A300", "MNOTE" }));
 }
 
@@ -861,7 +861,7 @@ TEST(diagnostics, mnote_long_message)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "A117", "MNOTE" }));
 }
 
@@ -874,7 +874,7 @@ TEST(diagnostics, iseq_number_of_operands)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A013");
 }
@@ -888,7 +888,7 @@ TEST(diagnostics, iseq_incorrect_op_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A120");
 }
@@ -902,7 +902,7 @@ TEST(diagnostics, push_print_specified)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A112");
 }
@@ -916,7 +916,7 @@ TEST(diagnostics, push_acontrol_specified)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A112");
 }
@@ -930,7 +930,7 @@ TEST(diagnostics, pop_noprint_first)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A113");
 }
@@ -944,7 +944,7 @@ TEST(diagnostics, pop_incorrect_last_operand)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A110");
 }
@@ -958,7 +958,7 @@ TEST(diagnostics, pop_only_noprint_specified)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A114");
 }
@@ -972,7 +972,7 @@ TEST(diagnostics, push_incorrect_op_value)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A111");
 }
@@ -986,7 +986,7 @@ TEST(diagnostics, org_incorrect_first_op)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "A245");
 }

--- a/parser_library/test/checking/data_definition/data_definition_length_test.cpp
+++ b/parser_library/test/checking/data_definition/data_definition_length_test.cpp
@@ -15,6 +15,7 @@
 #include "context/ordinary_assembly/ordinary_assembly_dependency_solver.h"
 #include "data_definition_common.h"
 #include "expressions/data_definition.h"
+#include "hlasmparser.h"
 #include "processing/instruction_sets/data_def_postponed_statement.h"
 #include "semantics/operand.h"
 

--- a/parser_library/test/checking/data_definition/data_definition_test.cpp
+++ b/parser_library/test/checking/data_definition/data_definition_test.cpp
@@ -15,6 +15,7 @@
 
 #include "../../common_testing.h"
 #include "context/ordinary_assembly/ordinary_assembly_dependency_solver.h"
+#include "hlasmparser.h"
 
 void expect_no_errors(const std::string& text)
 {

--- a/parser_library/test/checking/mach_instr_check_test.cpp
+++ b/parser_library/test/checking/mach_instr_check_test.cpp
@@ -105,7 +105,7 @@ TEST(machine_instr_check_test, second_par_omitted)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M004");
 }
@@ -119,7 +119,7 @@ TEST(machine_instr_check_test, displ_unsigned_size)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M130");
 }
@@ -133,7 +133,7 @@ TEST(machine_instr_check_test, displ_signed_size)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
 
@@ -146,7 +146,7 @@ TEST(machine_instr_check_test, displ_signed_err)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M130");
 }
@@ -160,7 +160,7 @@ TEST(machine_instr_check_test, db_incorrect_format)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M104");
 }
@@ -174,7 +174,7 @@ TEST(machine_instr_check_test, db_not_corresponding)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M131");
 }
@@ -188,7 +188,7 @@ TEST(machine_instr_check_test, dxb_second_par_incorrect)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M131");
 }
@@ -202,7 +202,7 @@ TEST(machine_instr_check_test, length_not_corresponding)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M132");
 }
@@ -216,7 +216,7 @@ TEST(machine_instr_check_test, dis_reg_not_corresponding)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M135");
 }
@@ -230,7 +230,7 @@ TEST(machine_instr_check_test, reg_not_corresponding)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M133");
 }
@@ -244,7 +244,7 @@ TEST(machine_instr_check_test, vec_reg_not_corresponding)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M134");
 }
@@ -258,7 +258,7 @@ TEST(machine_instr_check_test, displ_as_simple_unsigned)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M130");
 }
@@ -272,7 +272,7 @@ TEST(machine_instr_check_test, displ_as_simple_signed_correct)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
 
@@ -285,7 +285,7 @@ TEST(machine_instr_check_test, displ_as_simple_signed_err)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M130");
 }
@@ -299,7 +299,7 @@ TEST(machine_instr_check_test, immS_out_of_range)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M122");
 }
@@ -315,7 +315,7 @@ DISP     MVC  0(1),1
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M123");
 }
@@ -331,7 +331,7 @@ DISP     MVC 0(1),1
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
 
@@ -344,7 +344,7 @@ TEST(machine_instr_check_test, mask_out_of_range)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M121");
 }
@@ -358,7 +358,7 @@ TEST(machine_instr_check_test, immU_out_of_range)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M122");
 }
@@ -372,7 +372,7 @@ TEST(machine_instr_check_test, vecReg_out_of_range)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M124");
 }
@@ -386,7 +386,7 @@ TEST(machine_instr_check_test, mask_expected)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M111");
 }
@@ -400,7 +400,7 @@ TEST(machine_instr_check_test, imm_expected)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().at(0).code, "M112");
 }
@@ -414,6 +414,6 @@ TEST(machine_instr_check_test, vec_reg_limits)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }

--- a/parser_library/test/common_testing.cpp
+++ b/parser_library/test/common_testing.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+#include "common_testing.h"
+
+#include "hlasmparser.h"
+
+std::pair<bool, antlr4::ParserRuleContext*> try_parse_sll(hlasm_plugin::parser_library::parsing::hlasmparser& h_parser)
+{
+    h_parser.getInterpreter<antlr4::atn::ParserATNSimulator>()->setPredictionMode(
+        antlr4::atn::PredictionMode::SLL); // try with simpler/faster SLL(*)
+    // we don't want error messages or recovery during first try
+    h_parser.removeErrorListeners();
+    h_parser.setErrorHandler(std::make_shared<antlr4::BailErrorStrategy>());
+    try
+    {
+        auto tree = h_parser.program();
+        // if we get here, there was no syntax error and SLL(*) was enough;
+        // there is no need to try full LL(*)
+        return { true, tree };
+    }
+    catch (antlr4::RuntimeException&)
+    {
+        std::cout << "SLL FAILURE" << std::endl;
+
+        auto tokens = h_parser.getTokenStream();
+        std::cout << tokens->get(tokens->index())->getLine() << std::endl;
+        // The BailErrorStrategy wraps the RecognitionExceptions in
+        // RuntimeExceptions so we have to make sure we're detecting
+        // a true RecognitionException not some other kind
+        dynamic_cast<antlr4::BufferedTokenStream*>(tokens)->reset(); // rewind input stream
+        // back to standard listeners/handlers
+        h_parser.addErrorListener(&antlr4::ConsoleErrorListener::INSTANCE);
+        h_parser.setErrorHandler(std::make_shared<antlr4::DefaultErrorStrategy>());
+        h_parser.getInterpreter<antlr4::atn::ParserATNSimulator>()->setPredictionMode(
+            antlr4::atn::PredictionMode::LL); // try full LL(*)
+        auto tree = h_parser.program();
+        return { false, tree };
+    }
+}

--- a/parser_library/test/context/data_attribute_test.cpp
+++ b/parser_library/test/context/data_attribute_test.cpp
@@ -768,3 +768,30 @@ C    EQU  L'*
     EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "B"), 1);
     EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "C"), 1);
 }
+
+TEST(data_attributes, expression_without_spaces)
+{
+    std::string input = R"(
+        MACRO
+        MAC &P=
+&B      SETB ('&P'EQ'E'OR'&P'EQ'D'OR'&P'EQ'B')
+&P      EQU  &B
+        MEND
+
+        MAC P=A
+        MAC P=E
+        MAC P=D
+        MAC P=B
+)";
+
+    analyzer a(input);
+    a.analyze();
+
+    a.collect_diags();
+    EXPECT_TRUE(a.diags().empty());
+
+    EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "A"), 0);
+    EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "E"), 1);
+    EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "D"), 1);
+    EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "B"), 1);
+}

--- a/parser_library/test/context/data_attribute_test.cpp
+++ b/parser_library/test/context/data_attribute_test.cpp
@@ -795,3 +795,29 @@ TEST(data_attributes, expression_without_spaces)
     EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "D"), 1);
     EXPECT_EQ(get_symbol_abs(a.hlasm_ctx(), "B"), 1);
 }
+
+TEST(data_attributes, attribute_after_paren)
+{
+    std::string input = R"(
+    MACRO
+    MAC2 &P
+    GBLB &X
+&X  SETB (&P)
+    MEND
+    MACRO
+    MAC
+    MAC2 &SYSLIST(N'&SYSLIST)
+    MEND
+
+    GBLB &X
+    MAC  1
+)";
+
+    analyzer a(input);
+    a.analyze();
+
+    a.collect_diags();
+    EXPECT_TRUE(a.diags().empty());
+
+    EXPECT_EQ(get_var_value<B_t>(a.hlasm_ctx(), "X"), false);
+}

--- a/parser_library/test/context/data_attribute_test.cpp
+++ b/parser_library/test/context/data_attribute_test.cpp
@@ -819,5 +819,5 @@ TEST(data_attributes, attribute_after_paren)
     a.collect_diags();
     EXPECT_TRUE(a.diags().empty());
 
-    EXPECT_EQ(get_var_value<B_t>(a.hlasm_ctx(), "X"), false);
+    EXPECT_EQ(get_var_value<B_t>(a.hlasm_ctx(), "X"), true);
 }

--- a/parser_library/test/context/macro_test.cpp
+++ b/parser_library/test/context/macro_test.cpp
@@ -220,7 +220,7 @@ TEST(macro, macro_positional_param_subs)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_keyword_param)
@@ -238,7 +238,7 @@ TEST(macro, macro_keyword_param)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_undefined_keyword_param)
@@ -257,7 +257,7 @@ TEST(macro, macro_undefined_keyword_param)
     a.collect_diags();
     ASSERT_EQ(a.diags().size(), (size_t)1);
     ASSERT_EQ(a.diags().front().severity, diagnostic_severity::warning);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_param_expr)
@@ -278,7 +278,7 @@ TEST(macro, macro_param_expr)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)2);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_composite_param_no_err)
@@ -295,7 +295,7 @@ TEST(macro, macro_composite_param_no_err)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_composite_param_err)
@@ -312,7 +312,7 @@ TEST(macro, macro_composite_param_err)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 
@@ -330,7 +330,7 @@ TEST(macro, macro_name_param)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, macro_name_param_repetition)
@@ -357,7 +357,7 @@ TEST(macro, macro_name_param_repetition)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)3);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     auto& m1 = a.hlasm_ctx().macros().find(a.hlasm_ctx().ids().add("m1"))->second;
     auto& m2 = a.hlasm_ctx().macros().find(a.hlasm_ctx().ids().add("m2"))->second;
@@ -417,7 +417,7 @@ TEST(macro, MEXIT)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, cyclic_call_infinite)
@@ -436,7 +436,7 @@ TEST(macro, cyclic_call_infinite)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, cyclic_call_finite)
@@ -458,7 +458,7 @@ TEST(macro, cyclic_call_finite)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)10);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, arguments_concatenation)
@@ -486,7 +486,7 @@ TEST(macro, arguments_concatenation)
     EXPECT_EQ(it->second->access_set_symbol_base()->access_set_symbol<C_t>()->get_value(), "(B-C)+(A-D)");
 
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, arguments_continuation)
@@ -518,7 +518,7 @@ TEST(macro, arguments_continuation)
     EXPECT_EQ(W->second->access_set_symbol_base()->access_set_symbol<C_t>()->get_value(), "Y");
 
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 TEST(external_macro, bad_name)
 {
@@ -540,7 +540,7 @@ TEST(external_macro, bad_name)
     ASSERT_EQ(lib_provider.analyzers.count("MAC"), 1U);
     EXPECT_EQ(lib_provider.analyzers["MAC"]->diags().size(), 1U);
     EXPECT_EQ(a.diags().size(), 2U);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), 0U);
+    EXPECT_EQ(a.debug_syntax_errors(), 0U);
 }
 
 TEST(external_macro, bad_begin)
@@ -564,7 +564,7 @@ TEST(external_macro, bad_begin)
     ASSERT_EQ(lib_provider.analyzers.count("MAC"), 1U);
     EXPECT_EQ(lib_provider.analyzers["MAC"]->diags().size(), 1U);
     EXPECT_EQ(a.diags().size(), 2U);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), 0U);
+    EXPECT_EQ(a.debug_syntax_errors(), 0U);
 }
 
 TEST(external_macro, library_with_begin_comment)
@@ -588,7 +588,7 @@ TEST(external_macro, library_with_begin_comment)
     ASSERT_EQ(lib_provider.analyzers.count("MAC"), 1U);
     EXPECT_EQ(lib_provider.analyzers["MAC"]->diags().size(), 0U);
     EXPECT_EQ(a.diags().size(), 0U);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), 0U);
+    EXPECT_EQ(a.debug_syntax_errors(), 0U);
 }
 
 TEST(variable_argument_passing, positive_sublist)
@@ -700,7 +700,7 @@ TEST(macro, parse_args)
     a.collect_diags();
 
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, seq_numbers)
@@ -717,7 +717,7 @@ TEST(macro, seq_numbers)
     a.collect_diags();
 
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(macro, apostrophe_in_substitution)
@@ -735,7 +735,7 @@ TEST(macro, apostrophe_in_substitution)
     a.analyze();
     a.collect_diags();
 
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "MNOTE" }));
 }
 

--- a/parser_library/test/diagnostics_check_test.cpp
+++ b/parser_library/test/diagnostics_check_test.cpp
@@ -34,7 +34,7 @@ LABEL EQU *+2
     a.analyze();
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -60,7 +60,7 @@ TEST(diagnostics, string_substitution)
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -87,7 +87,7 @@ TEST(diagnostics, division_by_zero) // test ok
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -108,7 +108,7 @@ TEST(diagnostics, instr_zero_op) // test ok
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -131,7 +131,7 @@ TEST(diagnostics, unkown_symbols) // to do? number of errors?
 
         a.collect_diags();
 
-        ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+        ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
         ASSERT_EQ(a.diags().size(), (size_t)0);
 }*/
@@ -152,7 +152,7 @@ TEST(diagnostics, case_insensitivity)
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -173,7 +173,7 @@ TEST(diagnostics, machine)
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -236,7 +236,7 @@ LABEL2 equ *+79000
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     ASSERT_EQ(a.diags().size(), (size_t)0);
 }
@@ -292,7 +292,7 @@ label1 RSECT
 
     a.collect_diags();
 
-    ASSERT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    ASSERT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_TRUE(matches_message_codes(a.diags(), { "MNOTE" }));
 }

--- a/parser_library/test/parsing/parser_test.cpp
+++ b/parser_library/test/parsing/parser_test.cpp
@@ -54,7 +54,7 @@ TEST_F(library_test, simple)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 // 5 instruction statements that have 1,1,1,2 and 4 operands respectively
@@ -68,7 +68,7 @@ TEST_F(library_test, operand)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 // 3 alternative forms of instructions
@@ -80,7 +80,7 @@ TEST_F(library_test, continuation)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 // finding 3 variable symbols in model statement
@@ -93,7 +93,7 @@ TEST_F(library_test, model_statement)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 // simply parse correctly
@@ -107,7 +107,7 @@ TEST_F(library_test, comment)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 // simply parse correctly
@@ -131,7 +131,7 @@ TEST_F(library_test, long_macro)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 TEST_F(library_test, process_statement)
@@ -144,7 +144,7 @@ TEST_F(library_test, process_statement)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }
 
 TEST_F(library_test, macro_model)
@@ -157,5 +157,5 @@ TEST_F(library_test, macro_model)
 
     holder->analyze();
     // no errors found while parsing
-    ASSERT_EQ(holder->parser().getNumberOfSyntaxErrors(), size_t_zero);
+    ASSERT_EQ(holder->debug_syntax_errors(), size_t_zero);
 }

--- a/parser_library/test/processing/ainsert_test.cpp
+++ b/parser_library/test/processing/ainsert_test.cpp
@@ -399,7 +399,7 @@ TEST(ainsert, grammar_non_matching_apostrophes_by_two_01)
     AINSERT '       MEND',BACK
 
     MEND
-    
+
     MAC 1,2,3,4,5
     MAC_GEN 6,7,8,9
 )";
@@ -425,7 +425,7 @@ TEST(ainsert, grammar_non_matching_apostrophes_by_two_02)
                '''''',BACK
     
     MEND
-    
+
     MAC 1,2,3,4,5
 )";
 
@@ -453,7 +453,7 @@ TEST(ainsert, grammar_non_matching_apostrophes_by_one_01)
     AINSERT '       MEND',BACK
 
     MEND
-    
+
     MAC 1,2,3,4,5
     MAC_GEN 6,7,8,9
 )";
@@ -480,7 +480,7 @@ TEST(ainsert, grammar_non_matching_apostrophes_by_one_02)
                ''''''''',BACK
 
     MEND
-    
+
     MAC 1,2,3,4,5
 )";
 

--- a/parser_library/test/processing/copy_test.cpp
+++ b/parser_library/test/processing/copy_test.cpp
@@ -448,7 +448,7 @@ TEST(copy, inner_copy_jump)
     EXPECT_EQ(a.hlasm_ctx().copy_members().size(), (size_t)1);
 
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(copy, jump_from_copy_fail)
@@ -466,7 +466,7 @@ TEST(copy, jump_from_copy_fail)
     EXPECT_EQ(a.hlasm_ctx().copy_members().size(), (size_t)1);
 
     EXPECT_EQ(a.diags().size(), (size_t)2);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_EQ(a.diags()[1].diag_range.start.line, (size_t)2);
     EXPECT_EQ(a.diags()[1].file_name, "COPYJF");
@@ -501,7 +501,7 @@ TEST(copy, jump_in_macro_from_copy_fail)
     EXPECT_EQ(a.hlasm_ctx().copy_members().size(), (size_t)1);
 
     EXPECT_EQ(a.diags().size(), (size_t)2);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].file_name, "COPYJF");
@@ -533,7 +533,7 @@ TEST(copy, macro_nested_diagnostics)
     EXPECT_EQ(a.hlasm_ctx().copy_members().size(), (size_t)2);
 
     EXPECT_EQ(a.diags().size(), (size_t)1);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)4);
     EXPECT_EQ(a.diags()[0].file_name, "COPYND2");
@@ -563,7 +563,7 @@ TEST(copy, copy_call_with_jump_before_comment)
     EXPECT_EQ(a.hlasm_ctx().copy_members().size(), (size_t)1);
 
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(copy, copy_empty_file)

--- a/parser_library/test/processing/lookahead_test.cpp
+++ b/parser_library/test/processing/lookahead_test.cpp
@@ -16,6 +16,7 @@
 
 #include "../common_testing.h"
 #include "../mock_parse_lib_provider.h"
+#include "hlasmparser.h"
 
 // tests for lookahead feature:
 // forward/backward jums
@@ -55,7 +56,7 @@ TEST(lookahead, forward_jump_to_continued)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_FALSE(a.hlasm_ctx().get_var_sym(a.hlasm_ctx().ids().add("bad")));
     EXPECT_TRUE(a.hlasm_ctx().get_var_sym(a.hlasm_ctx().ids().add("good")));
@@ -78,7 +79,7 @@ TEST(lookahead, forward_jump_from_continued)
     a.analyze();
     a.collect_diags();
     EXPECT_EQ(a.diags().size(), (size_t)0);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 
     EXPECT_FALSE(a.hlasm_ctx().get_var_sym(a.hlasm_ctx().ids().add("bad")));
     EXPECT_TRUE(a.hlasm_ctx().get_var_sym(a.hlasm_ctx().ids().add("good")));
@@ -101,7 +102,7 @@ tr9023-22
     auto id = a.hlasm_ctx().ids().add("new");
     auto var = a.hlasm_ctx().get_var_sym(id);
     EXPECT_FALSE(var);
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
 }
 
 TEST(lookahead, forward_jump_fail)

--- a/parser_library/test/processing/mach_instr_test.cpp
+++ b/parser_library/test/processing/mach_instr_test.cpp
@@ -26,7 +26,7 @@ TEST(mach_instr_processing, reloc_imm_expected)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "M113" }));
 }
 
@@ -86,7 +86,7 @@ TEST(mach_instr_processing, vec_reg_expected)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(matches_message_codes(a.diags(), { "M114" }));
 }
 TEST(mach_instr_processing, reloc_symbol_expected)
@@ -112,7 +112,7 @@ TEST(mach_instr_processing, setc_variable_mnemonic_reloc_operand)
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(a.diags().empty());
 }
 TEST(mach_instr_processing, setc_variable_reloc_operand)
@@ -128,7 +128,7 @@ TEST CSECT
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(a.diags().empty());
 }
 TEST(mach_instr_processing, setc_variable_reloc_symbol_expected_warn)
@@ -160,7 +160,7 @@ LABEL   BRAS  0,*+12
     analyzer a(input);
     a.analyze();
     a.collect_diags();
-    EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
+    EXPECT_EQ(a.debug_syntax_errors(), (size_t)0);
     EXPECT_TRUE(a.diags().empty());
 }
 TEST(mach_instr_processing, reloc_parsed_in_macro_with_immValue)


### PR DESCRIPTION
(closes eclipse/che-che4z-lsp-for-hlasm#263)