### PR TITLE
Incorrect type data attribute for macro label when lookahead discovery succeeds

### DIFF
--- a/parser_library/src/expressions/conditional_assembly/terms/ca_symbol_attribute.cpp
+++ b/parser_library/src/expressions/conditional_assembly/terms/ca_symbol_attribute.cpp
@@ -233,21 +233,7 @@ context::SET_t ca_symbol_attribute::evaluate_ordsym(context::id_index name, cons
         const context::symbol* ord_symbol = eval_ctx.hlasm_ctx.ord_ctx.get_symbol(name);
 
         if (!ord_symbol)
-        {
-            if (attribute == context::data_attr_kind::T)
-            {
-                // it is not an ordinary symbol, but it could be
-                //
-                // Just to make clear what is going on here
-                // This special 'M' behavior is triggerred ONLY
-                // when the tested symbol is equal to the name field on the macro call
-                const auto& name_field = get_current_macro_name_field(eval_ctx.hlasm_ctx);
-                if (!name_field.empty() && iequals(*name, name_field))
-                    return "M";
-            }
-
             ord_symbol = eval_ctx.hlasm_ctx.ord_ctx.get_symbol_reference(name);
-        }
 
         return retrieve_value(ord_symbol, eval_ctx);
     }

--- a/parser_library/test/common_testing.h
+++ b/parser_library/test/common_testing.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -122,31 +123,25 @@ std::optional<std::unordered_map<size_t, T>> get_var_vector_map(hlasm_context& c
     return result;
 }
 
-inline bool matches_message_codes(const std::vector<diagnostic_op>& d, std::initializer_list<std::string> m)
+template<typename Msg, typename C = std::initializer_list<std::string>>
+inline bool matches_message_codes(const std::vector<Msg>& d, const C& c)
 {
     std::vector<std::string> codes;
     std::transform(d.begin(), d.end(), std::back_inserter(codes), [](const auto& d) { return d.code; });
 
-    return std::is_permutation(codes.begin(), codes.end(), m.begin(), m.end());
+    return std::is_permutation(codes.begin(), codes.end(), c.begin(), c.end());
 }
 
-inline bool matches_message_codes(const std::vector<diagnostic_s>& d, std::initializer_list<std::string> m)
+template<typename Msg, typename C = std::initializer_list<std::string>>
+inline bool contains_message_codes(const std::vector<Msg>& d, const C& c)
 {
-    std::vector<std::string> codes;
-    std::transform(d.begin(), d.end(), std::back_inserter(codes), [](const auto& d) { return d.code; });
-
-    return std::is_permutation(codes.begin(), codes.end(), m.begin(), m.end());
-}
-
-inline bool contains_message_codes(const std::vector<diagnostic_s>& d, std::initializer_list<std::string> m)
-{
-    if (d.size() < m.size())
+    if (d.size() < c.size())
         return false;
 
     std::vector<std::string> codes;
     std::transform(d.begin(), d.end(), std::back_inserter(codes), [](const auto& d) { return d.code; });
 
-    std::vector to_find(m.begin(), m.end());
+    std::vector to_find(c.begin(), c.end());
 
     std::sort(codes.begin(), codes.end());
     std::sort(to_find.begin(), to_find.end());


### PR DESCRIPTION
No changelog update - just a fix for a case I missed in the previous unreleased PR.