### PR TITLE
ci: Sonar workflow update for prev job failures

### DIFF
--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -21,6 +21,25 @@ on:
       - completed
 
 jobs:
+  sonar-prev-job-failure:
+    name: SonarCloud scan - previous job failure
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+
+    steps:
+     - name: Dump
+       run: |
+            echo Previous project ended unsuccessfully with conclusion &CONCLUSION
+            mkdir logs
+            echo ${{ github.event }} > logs/gh-event.txt
+       env:
+         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+     - uses: actions/upload-artifact@v2
+       with:
+          name: logs
+          path: |
+            logs/
+
   sonar:
     name: SonarCloud scan
     runs-on: ubuntu-20.04

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -29,16 +29,14 @@ jobs:
     steps:
      - name: Dump
        run: |
-            echo Previous project ended unsuccessfully with conclusion &CONCLUSION
-            mkdir logs
-            echo ${{ github.event }} > logs/gh-event.txt
-       env:
-         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-     - uses: actions/upload-artifact@v2
+            echo 'github.event details:'
+            echo '${{ toJSON(github.event) }}'
+    
+     - name: Issue error
+       uses: actions/github-script@v3
        with:
-          name: logs
-          path: |
-            logs/
+         script: |
+                 core.setFailed('Previous job ended unsuccessfully with the following conclusion: ${{ github.event.workflow_run.conclusion }}')
 
   sonar:
     name: SonarCloud scan


### PR DESCRIPTION
This is how it's gonna look when sonar cloud build is unsuccessful for any reason

![image](https://user-images.githubusercontent.com/99467904/181260041-4335941c-2d44-4371-8aff-e1f3880b25f2.png)

![image](https://user-images.githubusercontent.com/99467904/181260086-4bd19e08-aefe-4041-a131-ad9ed3acd75e.png)

![image](https://user-images.githubusercontent.com/99467904/181260109-450677e6-0bd1-4a54-8c14-6a641b43b9ae.png)

