### PR TITLE
fix: Comment highlighting improvements in TextMate grammar

### DIFF
--- a/clients/vscode-hlasmplugin/CHANGELOG.md
+++ b/clients/vscode-hlasmplugin/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Scale and integer attributes are not processed correctly
 - Statement operands are improperly cached after encountering OPSYN
 - Literals in listings are highlighted as instructions
+- Comment highlighting improvements in TextMate grammar
 
 ## [1.18.0](https://github.com/eclipse-che4z/che-che4z-lsp-for-hlasm/compare/1.17.0...1.18.0) (2025-06-20)
 

--- a/clients/vscode-hlasmplugin/scripts/syntaxes/hlasm_tmgrammar_template.txt
+++ b/clients/vscode-hlasmplugin/scripts/syntaxes/hlasm_tmgrammar_template.txt
@@ -140,9 +140,6 @@
           "include": "#sequenceSymbolOperandField"
         },
         {
-          "include": "#asmArguments"
-        },
-        {
           "match": "(?<=,)(\\s.*)(?<=^${listingDetails}$.{0,71})",
           "comment": "Operands will continue on next line",
           "captures": {
@@ -168,6 +165,9 @@
               "include": "#remarksLine"
             }
           ]
+        },
+        {
+          "include": "#asmArguments"
         },
         {
           "include": "#lineEnd"

--- a/clients/vscode-hlasmplugin/src/test/syntaxes/main/remarks.hlasm
+++ b/clients/vscode-hlasmplugin/src/test/syntaxes/main/remarks.hlasm
@@ -1,0 +1,3 @@
+         L     0,0                     remark
+         L     0,0                     (remark)
+         L     0,0                     'remark'

--- a/clients/vscode-hlasmplugin/src/test/syntaxes/main/remarks.hlasm.snap
+++ b/clients/vscode-hlasmplugin/src/test/syntaxes/main/remarks.hlasm.snap
@@ -1,0 +1,28 @@
+>         L     0,0                     remark
+#^^^^^^^^^ source.hlasm
+#         ^ source.hlasm entity.name.function.hlasm
+#          ^^^^^ source.hlasm
+#               ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                ^ source.hlasm
+#                 ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                  ^ source.hlasm
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hlasm comment.hlasm
+>         L     0,0                     (remark)
+#^^^^^^^^^ source.hlasm
+#         ^ source.hlasm entity.name.function.hlasm
+#          ^^^^^ source.hlasm
+#               ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                ^ source.hlasm
+#                 ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                  ^ source.hlasm
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hlasm comment.hlasm
+>         L     0,0                     'remark'
+#^^^^^^^^^ source.hlasm
+#         ^ source.hlasm entity.name.function.hlasm
+#          ^^^^^ source.hlasm
+#               ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                ^ source.hlasm
+#                 ^ source.hlasm punctuation.definition.tag.hlasm constant.numeric.hlasm
+#                  ^ source.hlasm
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hlasm comment.hlasm
+>


### PR DESCRIPTION
fixes eclipse-che4z/che-che4z-lsp-for-hlasm#306