### PR TITLE
test: Fix debug tests on VSCode Insiders

### DIFF
--- a/clients/vscode-hlasmplugin/src/test/suite/testHelper.ts
+++ b/clients/vscode-hlasmplugin/src/test/suite/testHelper.ts
@@ -107,6 +107,7 @@ function sessionStoppedEvent(session: vscode.DebugSession | undefined = vscode.d
 }
 
 export async function debugStartSession(waitForStopped = true): Promise<vscode.DebugSession> {
+    await vscode.commands.executeCommand('workbench.view.debug');
     const session_started_event = new Promise<vscode.DebugSession>((resolve) => {
         // when the debug session starts
         const disposable = vscode.debug.onDidStartDebugSession((session) => {

--- a/clients/vscode-hlasmplugin/src/test/suite/testHelper.ts
+++ b/clients/vscode-hlasmplugin/src/test/suite/testHelper.ts
@@ -107,7 +107,9 @@ function sessionStoppedEvent(session: vscode.DebugSession | undefined = vscode.d
 }
 
 export async function debugStartSession(waitForStopped = true): Promise<vscode.DebugSession> {
-    await vscode.commands.executeCommand('workbench.view.debug');
+    try { await vscode.commands.executeCommand('workbench.view.debug'); }
+    catch (_e) { /* theia */ }
+
     const session_started_event = new Promise<vscode.DebugSession>((resolve) => {
         // when the debug session starts
         const disposable = vscode.debug.onDidStartDebugSession((session) => {


### PR DESCRIPTION
VSCode Insiders only sends `scopes` request when the variables panel is visible.
Switch to Debug panel when starting a debug session.